### PR TITLE
ci: fix quality workflow push trigger to use master branch

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -3,7 +3,7 @@ name: Quality Check
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- The `quality.yml` workflow push trigger was configured for `main`, but the default branch is `master`
- CI was only running on pull requests, never on direct pushes to master
- Fixed by changing the branch name from `main` to `master`

## Test plan
- [ ] Verify the Quality Check workflow triggers on push to master after merge
- [ ] Confirm PR-triggered CI still works as before