### PR TITLE
chore: add unified deploy and local invoke scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ memory-bank
 .context
 
 packages/database/generated
+postgres-data
+jean.json

--- a/package.json
+++ b/package.json
@@ -16,7 +16,12 @@
     "check-api": "ts-node --transpile-only scripts/check-api-health.ts",
     "check-api:us": "ts-node --transpile-only scripts/check-api-health.ts us",
     "check-api:europe": "ts-node --transpile-only scripts/check-api-health.ts europe",
-    "check-api:australia": "ts-node --transpile-only scripts/check-api-health.ts australia"
+    "check-api:australia": "ts-node --transpile-only scripts/check-api-health.ts australia",
+    "invoke": "./scripts/invoke-local.sh",
+    "deploy": "turbo run deploy:production",
+    "deploy:mcall": "turbo run deploy:production --filter=@mcbroken/mcall",
+    "deploy:mcus": "turbo run deploy:production --filter=@mcbroken/mcus",
+    "deploy:mcau": "turbo run deploy:production --filter=@mcbroken/mcau"
   },
   "devDependencies": {
     "@mcbroken/eslint-config": "workspace:*",

--- a/scripts/invoke-local.sh
+++ b/scripts/invoke-local.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Usage: ./scripts/invoke-local.sh <app> <function> [extra serverless flags]
+#
+# Examples:
+#   ./scripts/invoke-local.sh mcall getItemStatusEu
+#   ./scripts/invoke-local.sh mcus getAllStores
+#   ./scripts/invoke-local.sh mcau getItemStatus
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+APP="${1:?Usage: invoke-local.sh <app> <function> [extra flags]}"
+FUNCTION="${2:?Usage: invoke-local.sh <app> <function> [extra flags]}"
+shift 2
+
+case "$APP" in
+  mcall|mcus|mcau) ;;
+  *)
+    echo "Error: Invalid app '$APP'. Must be one of: mcall, mcus, mcau"
+    exit 1
+    ;;
+esac
+
+APP_DIR="$ROOT_DIR/apps/$APP"
+PRISMA_DIR="$ROOT_DIR/packages/database/generated/prisma"
+LOCAL_ENGINE=$(find "$PRISMA_DIR" -name 'libquery_engine-*' ! -name '*rhel*' -maxdepth 1 2>/dev/null | head -1)
+
+if [ -z "$LOCAL_ENGINE" ]; then
+  echo "Error: No native Prisma engine found. Run 'pnpm turbo run db:generate' first."
+  exit 1
+fi
+
+echo "Invoking $APP/$FUNCTION locally..."
+cd "$APP_DIR" && pnpm invoke "$FUNCTION" -e "PRISMA_QUERY_ENGINE_LIBRARY=$LOCAL_ENGINE" "$@"


### PR DESCRIPTION
## Summary
- Add root-level `pnpm deploy` / `deploy:mcall` / `deploy:mcus` / `deploy:mcau` scripts that run turbo deploy pipeline across all regions
- Add `pnpm invoke <app> <function>` script that auto-detects the native Prisma engine, removing the need for manual `-e PRISMA_QUERY_ENGINE_LIBRARY=...` overrides
- Add `postgres-data` and `jean.json` to `.gitignore`

## Usage
```bash
# Deploy all regions (runs lint+test+build first)
pnpm deploy

# Deploy single region
pnpm deploy:mcall    # EU
pnpm deploy:mcus     # US
pnpm deploy:mcau     # AU

# Invoke locally
pnpm invoke mcall getItemStatusEu
pnpm invoke mcus getItemStatus
pnpm invoke mcau getAllStores
```

## Test plan
- [ ] `pnpm invoke mcall getItemStatusEu` returns `{ statusCode: 200, success: true }`
- [ ] `pnpm invoke invalid-app test` shows validation error
- [ ] `pnpm deploy:mcall` runs turbo pipeline correctly
- [ ] No changes to `packages/serverless-config/index.ts` — deployment behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)