### PR TITLE
Add deploy migration step and enable Sentry reporting

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,10 +55,40 @@ jobs:
       - name: Run verification
         run: pnpm verify
 
+  migrate-db:
+    name: Apply Database Migrations
+    runs-on: ubuntu-latest
+    needs: quality
+    if: ${{ inputs.target != 'frontend' }}
+    environment: ${{ inputs.environment }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Apply Prisma migrations
+        run: pnpm --filter @mcbroken/db db:deploy
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
   deploy-mcall:
     name: Deploy mcall
     runs-on: ubuntu-latest
-    needs: quality
+    needs:
+      - quality
+      - migrate-db
     if: ${{ inputs.target == 'all' || inputs.target == 'mcall' }}
     environment: ${{ inputs.environment }}
 
@@ -104,7 +134,9 @@ jobs:
   deploy-mcus:
     name: Deploy mcus
     runs-on: ubuntu-latest
-    needs: quality
+    needs:
+      - quality
+      - migrate-db
     if: ${{ inputs.target == 'all' || inputs.target == 'mcus' }}
     environment: ${{ inputs.environment }}
 
@@ -148,7 +180,9 @@ jobs:
   deploy-mcau:
     name: Deploy mcau
     runs-on: ubuntu-latest
-    needs: quality
+    needs:
+      - quality
+      - migrate-db
     if: ${{ inputs.target == 'all' || inputs.target == 'mcau' }}
     environment: ${{ inputs.environment }}
 

--- a/packages/database/prisma/migrations/20260319010500_add_pos_health_columns/migration.sql
+++ b/packages/database/prisma/migrations/20260319010500_add_pos_health_columns/migration.sql
@@ -1,0 +1,5 @@
+-- Add columns introduced by API health monitoring to keep Pos rows in sync
+-- with the Prisma schema and generated client.
+ALTER TABLE "Pos"
+ADD COLUMN "errorCounter" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN "isResponsive" BOOLEAN NOT NULL DEFAULT true;

--- a/packages/mclogik/src/sentry/index.test.ts
+++ b/packages/mclogik/src/sentry/index.test.ts
@@ -3,7 +3,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   addBreadcrumb,
   type BatchSummary,
-  captureBatchSummary
+  captureBatchSummary,
+  wrapHandler
 } from './index'
 
 vi.mock('@sentry/aws-serverless', () => {
@@ -211,5 +212,37 @@ describe('addBreadcrumb', () => {
       data: undefined,
       level: 'info',
     })
+  })
+})
+
+describe('wrapHandler', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('logs structured error details before rethrowing', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    process.env.AWS_LAMBDA_FUNCTION_NAME = 'test-function'
+
+    const error = new Error('boom')
+    const handler = wrapHandler(async () => {
+      throw error
+    })
+    const context = { awsRequestId: 'req-123' } as Parameters<typeof handler>[1]
+    const callback = (() => undefined) as Parameters<typeof handler>[2]
+
+    await expect(handler({}, context, callback)).rejects.toThrow('boom')
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Unhandled Lambda error',
+      expect.objectContaining({
+        functionName: 'test-function',
+        requestId: 'req-123',
+        name: 'Error',
+        message: 'boom',
+      })
+    )
+
+    consoleErrorSpy.mockRestore()
   })
 })

--- a/packages/mclogik/src/sentry/index.ts
+++ b/packages/mclogik/src/sentry/index.ts
@@ -28,7 +28,49 @@ export function initSentry(config: SentryConfig): void {
   })
 }
 
-export const wrapHandler = Sentry.wrapHandler
+function logUnhandledError(error: unknown, context?: unknown): void {
+  const requestId =
+    typeof context === 'object' &&
+    context !== null &&
+    'awsRequestId' in context &&
+    typeof context.awsRequestId === 'string'
+      ? context.awsRequestId
+      : undefined
+
+  if (error instanceof Error) {
+    console.error('Unhandled Lambda error', {
+      functionName: process.env.AWS_LAMBDA_FUNCTION_NAME,
+      requestId,
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    })
+    return
+  }
+
+  console.error('Unhandled Lambda error', {
+    functionName: process.env.AWS_LAMBDA_FUNCTION_NAME,
+    requestId,
+    error,
+  })
+}
+
+export function wrapHandler<TEvent = unknown, TResult = unknown>(
+  handler: (
+    event: TEvent,
+    context?: unknown,
+    callback?: unknown
+  ) => Promise<TResult> | TResult
+) {
+  return Sentry.wrapHandler(async (event: TEvent, context?: unknown, callback?: unknown) => {
+    try {
+      return await handler(event, context, callback)
+    } catch (error) {
+      logUnhandledError(error, context)
+      throw error
+    }
+  })
+}
 
 export { Sentry }
 

--- a/packages/mclogik/src/services/createJson/index.ts
+++ b/packages/mclogik/src/services/createJson/index.ts
@@ -7,7 +7,6 @@ import {
 import { prisma } from "@mcbroken/db/client";
 
 import { EXPORT_BUCKET } from "../../constants";
-import { Sentry } from "../../sentry";
 
 import { createGeoJson } from "./generateGeoJson";
 import { generateStats } from "./generateStats";
@@ -15,43 +14,35 @@ import { generateStats } from "./generateStats";
 const s3 = new S3Client({ region: "eu-central-1", apiVersion: "2012-10-17" });
 
 export async function createJson() {
-  try {
-    const allPos = await prisma.pos.findMany();
+  const allPos = await prisma.pos.findMany();
 
-    const json = createGeoJson(allPos);
-    const stats = await generateStats(prisma);
+  const json = createGeoJson(allPos);
+  const stats = await generateStats(prisma);
 
-    const paramsGeoJson: PutObjectCommandInput = {
-      Bucket: EXPORT_BUCKET,
-      Key: "marker.json",
-      Body: JSON.stringify(json),
-      ContentType: "application/json",
-      ACL: ObjectCannedACL.public_read,
-    };
+  const paramsGeoJson: PutObjectCommandInput = {
+    Bucket: EXPORT_BUCKET,
+    Key: "marker.json",
+    Body: JSON.stringify(json),
+    ContentType: "application/json",
+    ACL: ObjectCannedACL.public_read,
+  };
 
-    const paramsStatsJson: PutObjectCommandInput = {
-      Bucket: EXPORT_BUCKET,
-      Key: "stats.json",
-      Body: JSON.stringify(stats, (_key, value) => {
-        if (typeof value === "bigint") {
-          return Number(value);
-        }
+  const paramsStatsJson: PutObjectCommandInput = {
+    Bucket: EXPORT_BUCKET,
+    Key: "stats.json",
+    Body: JSON.stringify(stats, (_key, value) => {
+      if (typeof value === "bigint") {
+        return Number(value);
+      }
 
-        return value;
-      }),
-      ContentType: "application/json",
-      ACL: ObjectCannedACL.public_read,
-    };
+      return value;
+    }),
+    ContentType: "application/json",
+    ACL: ObjectCannedACL.public_read,
+  };
 
-    await Promise.all([
-      s3.send(new PutObjectCommand(paramsGeoJson)),
-      s3.send(new PutObjectCommand(paramsStatsJson)),
-    ]);
-  } catch (error) {
-    Sentry.withScope((scope) => {
-      scope.setTag("operation", "createJson");
-      Sentry.captureException(error);
-    });
-    throw error;
-  }
+  await Promise.all([
+    s3.send(new PutObjectCommand(paramsGeoJson)),
+    s3.send(new PutObjectCommand(paramsStatsJson)),
+  ]);
 }

--- a/packages/serverless-config/index.test.ts
+++ b/packages/serverless-config/index.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   getDeploymentStage,
   getExportBucket,
+  getOptionalEnv,
   getRequiredEnv,
   getServiceDeploymentBucket,
   getStageBucketName,
@@ -11,11 +12,13 @@ import {
 const ORIGINAL_SLS_STAGE = process.env.SLS_STAGE;
 const ORIGINAL_STAGE = process.env.STAGE;
 const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
+const ORIGINAL_SENTRY_DSN = process.env.SENTRY_DSN;
 
 afterEach(() => {
   process.env.SLS_STAGE = ORIGINAL_SLS_STAGE;
   process.env.STAGE = ORIGINAL_STAGE;
   process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
+  process.env.SENTRY_DSN = ORIGINAL_SENTRY_DSN;
 });
 
 describe("getDeploymentStage", () => {
@@ -93,5 +96,19 @@ describe("getRequiredEnv", () => {
     delete process.env.DATABASE_URL;
 
     expect(getRequiredEnv("DATABASE_URL")).toBe("${env:DATABASE_URL}");
+  });
+});
+
+describe("getOptionalEnv", () => {
+  it("returns the trimmed local env value when available", () => {
+    process.env.SENTRY_DSN = "  https://example.com/123  ";
+
+    expect(getOptionalEnv("SENTRY_DSN")).toBe("https://example.com/123");
+  });
+
+  it("returns undefined when the env is missing", () => {
+    delete process.env.SENTRY_DSN;
+
+    expect(getOptionalEnv("SENTRY_DSN")).toBeUndefined();
   });
 });

--- a/packages/serverless-config/index.ts
+++ b/packages/serverless-config/index.ts
@@ -40,6 +40,10 @@ export function getRequiredEnv(name: string): string {
   return getTrimmedValue(process.env[name]) ?? `\${env:${name}}`;
 }
 
+export function getOptionalEnv(name: string): string | undefined {
+  return getTrimmedValue(process.env[name]);
+}
+
 export function getStageBucketName(
   prefix: string,
   stage: string = getDeploymentStage(),
@@ -91,6 +95,11 @@ export const baseServerlessConfiguration: Partial<AWS> = {
       LOG_LEVEL: "NONE",
       PRISMA_QUERY_ENGINE_LIBRARY:
         "/var/task/node_modules/.prisma/client/libquery_engine-rhel-openssl-3.0.x.so.node",
+      SENTRY_ENVIRONMENT:
+        getOptionalEnv("SENTRY_ENVIRONMENT") ?? getDeploymentStage(),
+      ...(getOptionalEnv("SENTRY_DSN")
+        ? { SENTRY_DSN: getOptionalEnv("SENTRY_DSN") }
+        : {}),
     },
     architecture: "x86_64",
   },

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://turborepo.com/schema.json",
-  "globalEnv": ["ANALYZE", "MCBROKEN_ASSETS_ORIGIN", "SLS_STAGE", "STAGE"],
+  "globalEnv": [
+    "ANALYZE",
+    "MCBROKEN_ASSETS_ORIGIN",
+    "SLS_STAGE",
+    "STAGE",
+    "AWS_LAMBDA_FUNCTION_NAME"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
This PR adds a deploy-time Prisma migration job and includes the missing Pos health migration so database schema changes land before the serverless rollout. It also enables runtime Sentry env injection for the Lambda services, adds shared top-level error logging with AWS request context, and removes duplicate createJson exception capture. Tests were updated for the shared serverless config and Sentry wrapper behavior.