### PR TITLE
Restore DB-backed frontend data

### DIFF
--- a/apps/frontend/src/app/api/stats/route.ts
+++ b/apps/frontend/src/app/api/stats/route.ts
@@ -1,29 +1,15 @@
 import { NextResponse } from "next/server";
 
+import {
+  getStoreStats,
+  STORE_DATA_REVALIDATE_SECONDS,
+} from "@/server/store-data";
+
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
-const STORE_DATA_REVALIDATE_SECONDS = 300;
-const DEFAULT_ASSETS_ORIGIN =
-  "https://mcbrokenio-export-geojson-dev.s3.eu-central-1.amazonaws.com";
-
-function getStatsUrl(): string {
-  const origin =
-    process.env.MCBROKEN_ASSETS_ORIGIN?.replace(/\/$/, "") ??
-    DEFAULT_ASSETS_ORIGIN;
-
-  return `${origin}/stats.json`;
-}
 
 export async function GET() {
-  const response = await fetch(getStatsUrl(), {
-    cache: "no-store",
-  });
-
-  if (!response.ok) {
-    throw new Error(`Failed to fetch stats.json: ${response.status}`);
-  }
-
-  const storeStats = await response.json();
+  const storeStats = await getStoreStats();
 
   return NextResponse.json(storeStats, {
     headers: {

--- a/apps/frontend/src/server/store-data.ts
+++ b/apps/frontend/src/server/store-data.ts
@@ -8,10 +8,6 @@ import {
 } from "@mcbroken/mclogik/repositories";
 
 export const STORE_DATA_REVALIDATE_SECONDS = 300;
-const DEFAULT_ASSETS_ORIGIN =
-  "https://mcbrokenio-export-geojson-dev.s3.eu-central-1.amazonaws.com";
-
-type AssetKey = "marker.json" | "stats.json";
 
 const storeGeoJsonSelect = {
   id: true,
@@ -33,60 +29,23 @@ const storeGeoJsonSelect = {
   isResponsive: true,
 } satisfies Prisma.PosSelect;
 
-function getAssetsOrigin(): string {
-  return (
-    process.env.MCBROKEN_ASSETS_ORIGIN?.replace(/\/$/, "") ??
-    DEFAULT_ASSETS_ORIGIN
-  );
-}
-
-async function fetchAssetJson<T>(key: AssetKey): Promise<T> {
-  const response = await fetch(`${getAssetsOrigin()}/${key}`, {
-    cache: "no-store",
+export async function getStoreGeoJson(): Promise<GeoJson> {
+  const [{ prisma }, { createGeoJson }] = await Promise.all([
+    import("@mcbroken/db/client"),
+    import("@mcbroken/mclogik/geoJson"),
+  ]);
+  const stores: GeoJsonSourcePos[] = await prisma.pos.findMany({
+    select: storeGeoJsonSelect,
+    orderBy: [{ country: "asc" }, { id: "asc" }],
   });
 
-  if (!response.ok) {
-    throw new Error(`Failed to fetch ${key}: ${response.status}`);
-  }
-
-  return (await response.json()) as T;
-}
-
-export async function getStoreGeoJson(): Promise<GeoJson> {
-  if (!process.env.DATABASE_URL) {
-    return fetchAssetJson<GeoJson>("marker.json");
-  }
-
-  try {
-    const [{ prisma }, { createGeoJson }] = await Promise.all([
-      import("@mcbroken/db/client"),
-      import("@mcbroken/mclogik/geoJson"),
-    ]);
-    const stores: GeoJsonSourcePos[] = await prisma.pos.findMany({
-      select: storeGeoJsonSelect,
-      orderBy: [{ country: "asc" }, { id: "asc" }],
-    });
-
-    return createGeoJson(stores);
-  } catch (error) {
-    console.error("Falling back to exported store data", error);
-    return fetchAssetJson<GeoJson>("marker.json");
-  }
+  return createGeoJson(stores);
 }
 
 export async function getStoreStats(): Promise<CountryStats[]> {
-  if (!process.env.DATABASE_URL) {
-    return fetchAssetJson<CountryStats[]>("stats.json");
-  }
-
-  try {
-    const [{ prisma }, { createStatsRepository }] = await Promise.all([
-      import("@mcbroken/db/client"),
-      import("@mcbroken/mclogik/repositories"),
-    ]);
-    return createStatsRepository(prisma).getAggregatedStats();
-  } catch (error) {
-    console.error("Falling back to exported stats data", error);
-    return fetchAssetJson<CountryStats[]>("stats.json");
-  }
+  const [{ prisma }, { createStatsRepository }] = await Promise.all([
+    import("@mcbroken/db/client"),
+    import("@mcbroken/mclogik/repositories"),
+  ]);
+  return createStatsRepository(prisma).getAggregatedStats();
 }


### PR DESCRIPTION
Restores the frontend APIs to read from the database instead of the S3-exported JSON fallback. /api/stats is routed back through getStoreStats(), and the store-data helpers no longer fall back to marker.json or stats.json. I verified locally with the main .env that both /api/stores and /api/stats return 200 in production mode. The Vercel preview for this branch still returns 500 on both endpoints, which points to a Vercel DB env/connectivity issue that needs to be resolved before merge.