### PR TITLE
Fix serverless stage resolution for deploys

### DIFF
--- a/packages/serverless-config/index.test.ts
+++ b/packages/serverless-config/index.test.ts
@@ -11,33 +11,55 @@ import {
 
 const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
 const ORIGINAL_SENTRY_DSN = process.env.SENTRY_DSN;
+const ORIGINAL_SLS_STAGE = process.env.SLS_STAGE;
+const ORIGINAL_STAGE = process.env.STAGE;
 
 afterEach(() => {
   process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
   process.env.SENTRY_DSN = ORIGINAL_SENTRY_DSN;
+  process.env.SLS_STAGE = ORIGINAL_SLS_STAGE;
+  process.env.STAGE = ORIGINAL_STAGE;
 });
 
 describe("getDeploymentStage", () => {
-  it("always returns dev", () => {
-    // These env vars are intentionally ignored by getDeploymentStage.
-    // eslint-disable-next-line turbo/no-undeclared-env-vars
+  it("prefers SLS_STAGE when provided", () => {
     process.env.SLS_STAGE = "production";
-    // eslint-disable-next-line turbo/no-undeclared-env-vars
     process.env.STAGE = "staging";
+
+    expect(getDeploymentStage()).toBe("production");
+  });
+
+  it("falls back to STAGE when SLS_STAGE is missing", () => {
+    delete process.env.SLS_STAGE;
+    process.env.STAGE = "staging";
+
+    expect(getDeploymentStage()).toBe("staging");
+  });
+
+  it("defaults to dev when no stage env vars are present", () => {
+    delete process.env.SLS_STAGE;
+    delete process.env.STAGE;
 
     expect(getDeploymentStage()).toBe("dev");
   });
 });
 
 describe("bucket helpers", () => {
-  it("builds dev bucket names", () => {
+  it("builds stage-specific non-deployment bucket names", () => {
+    process.env.SLS_STAGE = "production";
+
     expect(getStageBucketName("mcbrokenio-assets")).toBe(
-      "mcbrokenio-assets-dev",
+      "mcbrokenio-assets-production",
     );
+    expect(getExportBucket()).toBe("mcbrokenio-export-geojson-production");
+  });
+
+  it("keeps deployment buckets on the shared dev bucket name", () => {
+    process.env.SLS_STAGE = "production";
+
     expect(getServiceDeploymentBucket("mcus")).toBe(
       "mcbrokenio-mcus-bucket-dev",
     );
-    expect(getExportBucket()).toBe("mcbrokenio-export-geojson-dev");
   });
 
   it("uses explicit overrides when provided", () => {

--- a/packages/serverless-config/index.ts
+++ b/packages/serverless-config/index.ts
@@ -8,7 +8,11 @@ function getTrimmedValue(value?: string): string | undefined {
 }
 
 export function getDeploymentStage(): string {
-  return DEFAULT_STAGE;
+  return (
+    getTrimmedValue(process.env.SLS_STAGE) ??
+    getTrimmedValue(process.env.STAGE) ??
+    DEFAULT_STAGE
+  );
 }
 
 export function getRequiredEnv(name: string): string {
@@ -23,18 +27,21 @@ export function getStageBucketName(
   prefix: string,
   override?: string,
 ): string {
-  return getTrimmedValue(override) ?? `${prefix}-${DEFAULT_STAGE}`;
+  return getTrimmedValue(override) ?? `${prefix}-${getDeploymentStage()}`;
 }
 
 export function getServiceDeploymentBucket(
   service: string,
   override?: string,
 ): string {
-  return getStageBucketName(`mcbrokenio-${service}-bucket`, override);
+  return getTrimmedValue(override) ?? `mcbrokenio-${service}-bucket-${DEFAULT_STAGE}`;
 }
 
 export function getExportBucket(override?: string): string {
-  return getTrimmedValue(override) ?? "mcbrokenio-export-geojson-dev";
+  return (
+    getTrimmedValue(override) ??
+    `mcbrokenio-export-geojson-${getDeploymentStage()}`
+  );
 }
 
 export const baseServerlessConfiguration: Partial<AWS> = {
@@ -59,13 +66,14 @@ export const baseServerlessConfiguration: Partial<AWS> = {
     apiGateway: {
       minimumCompressionSize: 1024,
     },
-    stage: DEFAULT_STAGE,
+    stage: getDeploymentStage(),
     environment: {
       AWS_NODEJS_CONNECTION_REUSE_ENABLED: "1",
       LOG_LEVEL: "NONE",
       PRISMA_QUERY_ENGINE_LIBRARY:
         "/var/task/node_modules/.prisma/client/libquery_engine-rhel-openssl-3.0.x.so.node",
-      SENTRY_ENVIRONMENT: getOptionalEnv("SENTRY_ENVIRONMENT") ?? DEFAULT_STAGE,
+      SENTRY_ENVIRONMENT:
+        getOptionalEnv("SENTRY_ENVIRONMENT") ?? getDeploymentStage(),
       ...(getOptionalEnv("SENTRY_DSN")
         ? { SENTRY_DSN: getOptionalEnv("SENTRY_DSN") }
         : {}),

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,9 @@
   "globalEnv": [
     "ANALYZE",
     "MCBROKEN_ASSETS_ORIGIN",
-    "AWS_LAMBDA_FUNCTION_NAME"
+    "AWS_LAMBDA_FUNCTION_NAME",
+    "SLS_STAGE",
+    "STAGE"
   ],
   "tasks": {
     "build": {
@@ -75,6 +77,8 @@
         "MCALL_DEPLOYMENT_BUCKET",
         "MCAU_DEPLOYMENT_BUCKET",
         "MCUS_DEPLOYMENT_BUCKET",
+        "SLS_STAGE",
+        "STAGE",
         "SENTRY_DSN",
         "SENTRY_ENVIRONMENT"
       ],


### PR DESCRIPTION
## Summary
Teach the shared serverless config to honor SLS_STAGE/STAGE instead of always deploying to dev.
Keep service deployment buckets on the shared -dev naming convention while making export buckets and Sentry environment stage-aware.
Expand the serverless-config tests to cover stage resolution, stage-specific bucket naming, and the shared deployment-bucket fallback.