### PR TITLE
Fix Spain mobile ordering facility string

### DIFF
--- a/docs/API/EL.md
+++ b/docs/API/EL.md
@@ -52,7 +52,7 @@
 | Slovenia             | SI   | false           |                                 |
 | South Africa         | SAR  | false           |                                 |
 | South Korea          | KR   | false           |                                 |
-| Spain                | ES   | true            | Pedido móvil para recoger en restaurante |
+| Spain                | ES   | true            | MyMcDonald's Pide y Paga |
 | Sweden               | SE   | true            | Mobil beställning och betalning |
 | Swiss                | CH   | true            | Mobil bestellen und bezahlen    |
 | Thailand             | TH   | false           |                                 |

--- a/packages/mclogik/src/constants/CountryInfos/El.ts
+++ b/packages/mclogik/src/constants/CountryInfos/El.ts
@@ -664,7 +664,7 @@ export const El: Record<ElLocations, ICountryInfos> = {
     getStores: {
       api: APIType.EL,
       url: 'https://api.me2-prd.gmal.app/api/locationfinder/v1/restaurants/es/es-es',
-      mobileString: 'Pedido móvil para recoger en restaurante'
+      mobileString: 'MyMcDonald\'s Pide y Paga'
     },
     productCodes: {
       [IceType.MILCHSHAKE]: ['UNAVAILABLE'],


### PR DESCRIPTION
Updates the Spain EL mobile-ordering facility label to match the current McDonald's location API response. This restores Spain stores to the trackable set for the status updater instead of leaving them visible with stale last-checked timestamps. The API notes were updated to keep the documented string in sync.